### PR TITLE
feat: webhook self call for Eventarc-triggered events

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -e
 
-export PROJECT_ID="velociraptor-16p1-test-0"
+export PROJECT_ID="velociraptor-16p1-test-13"
 export TF_PLAN_STORAGE_BUCKET="${PROJECT_ID?}-tf"
 export BUCKET_NAME=${TF_PLAN_STORAGE_BUCKET?}-main
 export TERRAFORM_IMAGE="hashicorp/terraform:1.4.6"

--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,7 @@ resource "google_service_account" "webhook" {
 resource "google_project_iam_member" "webhook_sa_roles" {
   project = var.project_id
   for_each = toset([
+    "roles/run.invoker",
     "roles/cloudfunctions.invoker",
     "roles/storage.admin",
     "roles/logging.logWriter",

--- a/webhook/main.py
+++ b/webhook/main.py
@@ -17,6 +17,10 @@ import os
 from google.cloud import logging
 import vertexai
 from vertexai.preview.language_models import TextGenerationModel
+import google.auth.transport.requests
+import google.oauth2.id_token
+import requests
+import flask
 
 from bigquery import write_summarization_to_table
 from document_extract import async_document_extract
@@ -68,22 +72,56 @@ def summarize_text(text: str, parameters: None | dict[str, int | float] = None) 
     return response.text
 
 
+def redirect_and_reply(previous_data):
+    endpoint = f'https://{_LOCATION}-{_PROJECT_ID}.cloudfunctions.net/{os.environ["K_SERVICE"]}'
+    logging_client = logging.Client()
+    logger = logging_client.logger(_FUNCTIONS_VERTEX_EVENT_LOGGER)
+
+    auth_req = google.auth.transport.requests.Request()
+    id_token = google.oauth2.id_token.fetch_id_token(auth_req, endpoint)
+    data = {
+        'name': previous_data["name"],
+        'id': previous_data["id"],
+        'bucket': previous_data["bucket"],
+        'timeCreated': previous_data["timeCreated"],
+    }
+    headers = {}
+    headers["Authorization"] = f"Bearer {id_token}"
+    logger.log(f'TRIGGERING JOB FLOW: {endpoint}')
+    try:
+        requests.post(
+            endpoint,
+            json=data,
+            timeout=1,
+            headers=headers,
+        )
+    except requests.exceptions.Timeout:
+        return flask.Response(status=200)
+    except Exception:
+        return flask.Response(status=500)
+    return flask.Response(status=200)
+    
+
 def entrypoint(request: object) -> dict[str, str]:
     data = request.get_json()
     if data.get("kind", None) == "storage#object":
-        return cloud_event_entrypoint(
-            name=data["name"],
-            event_id=data["id"],
-            bucket=data["bucket"],
-            time_created=coerce_datetime_zulu(data["timeCreated"]),
-        )
+        # Entrypoint called by Pub-Sub (Eventarc)
+        return redirect_and_reply(data)
     else:
-        return summarization_entrypoint(
-            name=data["name"],
-            extracted_text=data["text"],
-            time_created=datetime.datetime.now(datetime.timezone.utc),
-            event_id="CURL_TRIGGER",
-        )
+        if 'bucket' in data:
+            return cloud_event_entrypoint(
+                name=data["name"],
+                event_id=data["id"],
+                bucket=data["bucket"],
+                time_created=coerce_datetime_zulu(data["timeCreated"]),
+            )
+        elif "text" in data:
+            return summarization_entrypoint(
+                name=data["name"],
+                extracted_text=data["text"],
+                time_created=datetime.datetime.now(datetime.timezone.utc),
+                event_id="CURL_TRIGGER",
+            )
 
 
 def cloud_event_entrypoint(event_id, bucket, name, time_created):

--- a/webhook/requirements.txt
+++ b/webhook/requirements.txt
@@ -20,3 +20,4 @@ google-cloud-bigquery==3.10.0
 google-cloud-logging==3.5.0
 google-cloud-storage==2.9.0
 google-cloud-vision==3.4.1
+requests==2.31.0


### PR DESCRIPTION
Solve retry issue by letting the webhook call itself, and escape any timeout errors so that the original call can still respond to pub/sub (the transport mechanism for the Eventarc call) with a 200 (i.e. request ack and send for processing).

