### PR TITLE
fix: add uuid suffix for unique bucket names

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Deployment: 10 mins
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| bucket\_name | The name of the bucket to create | `string` | `"genai-doc-summary-webhook-1234"` | no |
+| bucket\_name | The name of the bucket to create | `string` | `"genai-doc-summary-webhook"` | no |
 | gcf\_timeout\_seconds | GCF execution timeout | `number` | `900` | no |
 | project\_id | The Google Cloud project ID to deploy to | `string` | n/a | yes |
 | region | Google Cloud region | `string` | `"us-central1"` | no |

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-resource "random_id" "id" {
-  byte_length = 4
-}
-
 module "simple" {
   source       = "../../"
   project_id   = var.project_id
   webhook_path = abspath("../../webhook")
-  bucket_name  = "cft-test-${random_id.id.hex}"
 }

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,9 @@ resource "time_sleep" "wait_for_apis" {
   create_duration = var.time_to_enable_apis
 }
 
+resource "random_uuid" "rand" {
+}
+
 data "archive_file" "webhook" {
   type        = "zip"
   source_dir  = var.webhook_path
@@ -120,7 +123,7 @@ resource "google_cloudfunctions2_function" "webhook" {
     entry_point = "entrypoint"
     source {
       storage_source {
-        bucket = var.bucket_name
+        bucket = "${var.bucket_name}-${random_uuid.rand.id}"
         object = google_storage_bucket_object.webhook.name
       }
     }
@@ -223,7 +226,7 @@ resource "google_storage_bucket" "output" {
 
 resource "google_storage_bucket" "main" {
   project                     = var.project_id
-  name                        = var.bucket_name
+  name                        = "${var.bucket_name}-${random_uuid.rand.id}"
   location                    = "US"
   uniform_bucket_level_access = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "project_id" {
 variable "bucket_name" {
   description = "The name of the bucket to create"
   type        = string
-  default     = "genai-doc-summary-webhook-1234"
+  default     = "genai-doc-summary-webhook"
 }
 
 variable "region" {

--- a/versions.tf
+++ b/versions.tf
@@ -37,6 +37,10 @@ terraform {
       source  = "hashicorp/time"
       version = "~> 0.9.1"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
   }
 
   provider_meta "google" {

--- a/webhook/requirements.txt
+++ b/webhook/requirements.txt
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 flask==2.3.2
+# pyyaml installation is broken due to cython issues
+# https://github.com/yaml/pyyaml/issues/724
+pyyaml==5.3.1
 functions-framework==3.3.0
 google-auth==2.17.3
 google-cloud-aiplatform[pipelines]==1.25.0


### PR DESCRIPTION
Add uuid suffix to avoid bucket name collision globally
Pin pyyaml to avoid external deps install issue. This is throwing a CF build error