### PR TITLE
Shorten storage bucket name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,9 @@ resource "time_sleep" "wait_for_apis" {
 }
 
 resource "random_uuid" "rand" {
+  length           = 16
+  special          = true
+  override_special = "/@£$"
 }
 
 data "archive_file" "webhook" {
@@ -123,7 +126,7 @@ resource "google_cloudfunctions2_function" "webhook" {
     entry_point = "entrypoint"
     source {
       storage_source {
-        bucket = "${var.bucket_name}-${random_uuid.rand.id}"
+        bucket = "webhook-${random_uuid.rand.id}"
         object = google_storage_bucket_object.webhook.name
       }
     }
@@ -226,7 +229,7 @@ resource "google_storage_bucket" "output" {
 
 resource "google_storage_bucket" "main" {
   project                     = var.project_id
-  name                        = "${var.bucket_name}-${random_uuid.rand.id}"
+  name                        = "webhook-${random_uuid.rand.id}"
   location                    = "US"
   uniform_bucket_level_access = true
 }


### PR DESCRIPTION
Sometimes I encounter the errors that the bucket name is too long when testing. 
Renamed it to shorter string.