### PR TITLE
chore: [Do not merge] Replace Terraform with JSS 22.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,288 +16,248 @@
 
 module "project_services" {
   source                      = "terraform-google-modules/project-factory/google//modules/project_services"
-  version                     = "~> 14.2"
-  disable_services_on_destroy = false
+  version                     = "~> 14.4"
+  disable_services_on_destroy = var.disable_services_on_destroy
 
   project_id = var.project_id
 
   activate_apis = [
-    "serviceusage.googleapis.com",
-    "vision.googleapis.com",
-    "cloudfunctions.googleapis.com",
-    "serviceusage.googleapis.com",
-    "artifactregistry.googleapis.com",
-    "eventarc.googleapis.com",
-    "bigquery.googleapis.com",
     "aiplatform.googleapis.com",
-    "storage.googleapis.com",
+    "artifactregistry.googleapis.com",
     "cloudbuild.googleapis.com",
-    "run.googleapis.com",
+    "compute.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "config.googleapis.com",
     "iam.googleapis.com",
-    "notebooks.googleapis.com",
-    "dataform.googleapis.com",
+    "documentai.googleapis.com",
+    "eventarc.googleapis.com",
+    "firestore.googleapis.com",
+    "run.googleapis.com",
+    "serviceusage.googleapis.com",
+    "storage-api.googleapis.com",
+    "storage.googleapis.com",
   ]
 }
 
-data "google_project" "project" {
-  project_id = var.project_id
-  depends_on = [
-    module.project_services,
-  ]
+resource "random_id" "unique_id" {
+  byte_length = 3
 }
 
-resource "google_project_service_identity" "eventarc" {
-  provider = google-beta
-
-  project = data.google_project.project.project_id
-  service = "eventarc.googleapis.com"
-
-  depends_on = [
-    module.project_services,
-  ]
+locals {
+  bucket_main_name   = var.unique_names ? "${var.project_id}-main-${random_id.unique_id.hex}" : "${var.project_id}-main"
+  bucket_docs_name   = var.unique_names ? "${var.project_id}-docs-${random_id.unique_id.hex}" : "${var.project_id}-docs"
+  webhook_name       = var.unique_names ? "webhook-${random_id.unique_id.hex}" : "webhook"
+  webhook_sa_name    = var.unique_names ? "webhook-service-account-${random_id.unique_id.hex}" : "webhook-service-account"
+  trigger_name       = var.unique_names ? "trigger-${random_id.unique_id.hex}" : "trigger"
+  trigger_sa_name    = var.unique_names ? "trigger-service-account-${random_id.unique_id.hex}" : "trigger-service-account"
+  ocr_processor_name = var.unique_names ? "ocr-processor-${random_id.unique_id.hex}" : "ocr-processor"
+  docs_index_name    = var.unique_names ? "docs-index-${random_id.unique_id.hex}" : "docs-index"
+  firestore_name     = var.unique_names ? "knowledge-base-${random_id.unique_id.hex}" : "knowledge-base"
 }
 
-resource "google_project_iam_member" "eventarc_sa_role" {
-  project = data.google_project.project.project_id
-  role    = "roles/eventarc.serviceAgent"
-  member  = "serviceAccount:${google_project_service_identity.eventarc.email}"
+#-- Cloud Storage buckets --#
+resource "google_storage_bucket" "main" {
+  project                     = module.project_services.project_id
+  name                        = local.bucket_main_name
+  location                    = var.region
+  force_destroy               = true
+  uniform_bucket_level_access = true
 }
 
-resource "null_resource" "previous_time" {}
-
-# Gate till APIs are enabled
-resource "time_sleep" "wait_for_apis" {
-  depends_on = [
-    null_resource.previous_time,
-    module.project_services,
-    google_project_iam_member.eventarc_sa_role,
-  ]
-
-  create_duration = var.time_to_enable_apis
+resource "google_storage_bucket" "docs" {
+  project                     = module.project_services.project_id
+  name                        = local.bucket_docs_name
+  location                    = var.region
+  force_destroy               = true
+  uniform_bucket_level_access = true
 }
 
-resource "random_id" "rand" {
-  byte_length = 4
-}
-
-data "archive_file" "webhook" {
-  type        = "zip"
-  source_dir  = var.webhook_path
-  output_path = abspath("./.tmp/${var.webhook_name}.zip")
-}
-
-resource "google_storage_bucket_object" "webhook" {
-  name   = "${var.webhook_name}.${data.archive_file.webhook.output_base64sha256}.zip"
-  bucket = google_storage_bucket.main.name
-  source = data.archive_file.webhook.output_path
-}
-
-resource "google_service_account" "webhook" {
-  project      = var.project_id
-  account_id   = "webhook-service-account"
-  display_name = "Serverless Webhooks Service Account"
-  depends_on = [
-    module.project_services,
-  ]
-}
-
-resource "google_project_iam_member" "webhook_sa_roles" {
-  project = var.project_id
-  for_each = toset([
-    "roles/run.invoker",
-    "roles/cloudfunctions.invoker",
-    "roles/storage.admin",
-    "roles/logging.logWriter",
-    "roles/artifactregistry.reader",
-    "roles/bigquery.dataEditor",
-    "roles/aiplatform.user",
-  ])
-  role   = each.key
-  member = "serviceAccount:${google_service_account.webhook.email}"
-}
-
+#-- Cloud Function webhook --#
 resource "google_cloudfunctions2_function" "webhook" {
-  project  = var.project_id
-  name     = var.webhook_name
+  project  = module.project_services.project_id
+  name     = local.webhook_name
   location = var.region
 
   build_config {
-    runtime     = "python310"
-    entry_point = "entrypoint"
+    runtime           = "python312"
+    entry_point       = "on_cloud_event"
+    docker_repository = google_artifact_registry_repository.webhook_images.id
     source {
       storage_source {
-        bucket = "${var.bucket_name}-${random_id.rand.hex}"
-        object = google_storage_bucket_object.webhook.name
+        bucket = google_storage_bucket.main.name
+        object = google_storage_bucket_object.webhook_staging.name
       }
     }
   }
 
-
   service_config {
-    service_account_email            = google_service_account.webhook.email
-    max_instance_count               = 5
-    available_memory                 = "4G"
-    available_cpu                    = 1
-    max_instance_request_concurrency = 5
-    timeout_seconds                  = var.gcf_timeout_seconds
+    available_memory      = "4G"
+    timeout_seconds       = 300 # 5 minutes
+    service_account_email = google_service_account.webhook.email
     environment_variables = {
-      PROJECT_ID    = var.project_id
-      LOCATION      = var.region
-      OUTPUT_BUCKET = google_storage_bucket.output.name
-      DATASET_ID    = google_bigquery_dataset.default.dataset_id
-      TABLE_ID      = google_bigquery_table.default.table_id
+      PROJECT_ID        = module.project_services.project_id
+      VERTEXAI_LOCATION = var.region
+      OUTPUT_BUCKET     = google_storage_bucket.main.name
+      DOCAI_PROCESSOR   = google_document_ai_processor.ocr.id
+      DOCAI_LOCATION    = google_document_ai_processor.ocr.location
+      DATABASE          = google_firestore_database.main.name
+      INDEX_ID          = google_vertex_ai_index.docs.id
     }
   }
-  depends_on = [
-    module.project_services,
-    time_sleep.wait_for_apis,
-    google_project_iam_member.webhook_sa_roles,
+}
 
+resource "google_project_iam_member" "webhook" {
+  project = module.project_services.project_id
+  member  = google_service_account.webhook.member
+  for_each = toset([
+    "roles/aiplatform.serviceAgent", # https://cloud.google.com/iam/docs/service-agents
+    "roles/datastore.user",          # https://cloud.google.com/datastore/docs/access/iam
+    "roles/documentai.apiUser",      # https://cloud.google.com/document-ai/docs/access-control/iam-roles
+  ])
+  role = each.key
+}
+resource "google_service_account" "webhook" {
+  project      = module.project_services.project_id
+  account_id   = local.webhook_sa_name
+  display_name = "Cloud Functions webhook service account"
+}
+
+resource "google_artifact_registry_repository" "webhook_images" {
+  project       = module.project_services.project_id
+  location      = var.region
+  repository_id = "webhook-images"
+  format        = "DOCKER"
+}
+
+data "archive_file" "webhook_staging" {
+  type       = "zip"
+  source_dir = var.webhook_path
+  excludes = [
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    "env",
   ]
+  output_path = abspath("./.tmp/webhook.zip")
 }
 
-resource "google_bigquery_dataset" "default" {
-  dataset_id = "summary_dataset"
-  project    = var.project_id
-  depends_on = [
-    module.project_services,
-  ]
+resource "google_storage_bucket_object" "webhook_staging" {
+  name   = "webhook-staging/${data.archive_file.webhook_staging.output_base64sha256}.zip"
+  bucket = google_storage_bucket.main.name
+  source = data.archive_file.webhook_staging.output_path
 }
 
-resource "google_bigquery_table" "default" {
-  dataset_id          = google_bigquery_dataset.default.dataset_id
-  table_id            = "summary_table"
-  project             = var.project_id
-  deletion_protection = false
+#-- Eventarc trigger --#
+resource "google_eventarc_trigger" "trigger" {
+  project         = module.project_services.project_id
+  location        = var.region
+  name            = local.trigger_name
+  service_account = google_service_account.trigger.email
 
-  schema = <<EOF
-[
-  {
-    "name": "bucket",
-    "type": "STRING",
-    "description": "Source bucket of artifact"
-  },
-  {
-    "name": "filename",
-    "type": "STRING",
-    "description": "Filename of the source artifact"
-  },
-  {
-    "name": "extracted_text",
-    "type": "STRING",
-    "description": "Text extracted from the source artifact"
-  },
-  {
-    "name": "summary_uri",
-    "type": "STRING",
-    "description": "The Storage URI of the complete document text"
-  },
-  {
-    "name": "complete_text_uri",
-    "type": "STRING",
-    "description": "The Storage URI of the complete document text"
-  },
-  {
-    "name": "summary",
-    "type": "STRING",
-    "description": "Text summary generated by the LLM"
-  },
-  {
-    "name": "timestamp",
-    "type": "TIMESTAMP",
-    "description": "TeTimestamp that the processing occurred on"
-  }
-]
-EOF
-}
-
-resource "google_storage_bucket" "uploads" {
-  project                     = var.project_id
-  name                        = "${var.project_id}_uploads"
-  location                    = var.region
-  force_destroy               = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket" "output" {
-  project                     = var.project_id
-  name                        = "${var.project_id}_output"
-  location                    = var.region
-  force_destroy               = true
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket" "main" {
-  project                     = var.project_id
-  name                        = "${var.bucket_name}-${random_id.rand.hex}"
-  location                    = "US"
-  uniform_bucket_level_access = true
-}
-
-resource "google_service_account" "upload_trigger" {
-  project      = var.project_id
-  account_id   = "upload-trigger-service-account"
-  display_name = "Eventarc Service Account"
-  depends_on = [
-    module.project_services,
-  ]
-}
-
-resource "google_project_iam_member" "event_receiver" {
-  project = var.project_id
-  role    = "roles/eventarc.eventReceiver"
-  member  = "serviceAccount:${google_service_account.upload_trigger.email}"
-  depends_on = [
-    module.project_services,
-  ]
-}
-
-resource "google_project_iam_member" "run_invoker" {
-  project = var.project_id
-  role    = "roles/run.invoker"
-  member  = "serviceAccount:${google_service_account.upload_trigger.email}"
-  depends_on = [
-    module.project_services,
-  ]
-}
-
-data "google_storage_project_service_account" "gcs_account" {
-  project    = var.project_id
-  depends_on = [time_sleep.wait_for_apis]
-}
-
-resource "google_project_iam_member" "pubsub_publisher" {
-  project = var.project_id
-  role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
-  depends_on = [
-    module.project_services,
-    data.google_storage_project_service_account.gcs_account,
-  ]
-}
-
-resource "google_eventarc_trigger" "summarization" {
-  project  = var.project_id
-  name     = "terraformdev"
-  location = var.region
   matching_criteria {
     attribute = "type"
     value     = "google.cloud.storage.object.v1.finalized"
   }
   matching_criteria {
     attribute = "bucket"
-    value     = google_storage_bucket.uploads.name
+    value     = google_storage_bucket.docs.name
   }
+
   destination {
     cloud_run_service {
       service = google_cloudfunctions2_function.webhook.name
       region  = var.region
     }
   }
-  service_account = google_service_account.upload_trigger.email
-  depends_on = [
-    google_project_iam_member.event_receiver,
-    google_project_iam_member.run_invoker,
-    google_project_iam_member.pubsub_publisher,
-  ]
+}
+
+resource "google_project_iam_member" "trigger" {
+  project = module.project_services.project_id
+  member  = google_service_account.trigger.member
+  for_each = toset([
+    "roles/eventarc.eventReceiver", # https://cloud.google.com/eventarc/docs/access-control
+    "roles/run.invoker",            # https://cloud.google.com/run/docs/reference/iam/roles
+  ])
+  role = each.key
+}
+resource "google_service_account" "trigger" {
+  project      = module.project_services.project_id
+  account_id   = local.trigger_sa_name
+  display_name = "Eventarc trigger service account"
+}
+
+#-- Cloud Storage Eventarc agent --#
+resource "google_project_iam_member" "gcs_account" {
+  project = module.project_services.project_id
+  member  = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+  role    = "roles/pubsub.publisher" # https://cloud.google.com/pubsub/docs/access-control
+}
+data "google_storage_project_service_account" "gcs_account" {
+  project = module.project_services.project_id
+}
+
+resource "google_project_iam_member" "eventarc_agent" {
+  project = module.project_services.project_id
+  member  = "serviceAccount:${google_project_service_identity.eventarc_agent.email}"
+  role    = "roles/eventarc.serviceAgent" # https://cloud.google.com/iam/docs/service-agents
+}
+resource "google_project_service_identity" "eventarc_agent" {
+  provider = google-beta
+  project  = module.project_services.project_id
+  service  = "eventarc.googleapis.com"
+}
+
+#-- Document AI --#
+resource "google_document_ai_processor" "ocr" {
+  project      = module.project_services.project_id
+  location     = var.documentai_location
+  display_name = local.ocr_processor_name
+  type         = "OCR_PROCESSOR"
+}
+
+#-- Firestore --#
+resource "google_firestore_database" "main" {
+  project         = module.project_services.project_id
+  name            = local.firestore_name
+  location_id     = var.firestore_location
+  type            = "FIRESTORE_NATIVE"
+  deletion_policy = "DELETE"
+}
+
+#-- Vertex AI Vector Search --#
+resource "google_vertex_ai_index" "docs" {
+  project             = module.project_services.project_id
+  region              = var.region
+  display_name        = local.docs_index_name
+  index_update_method = "STREAM_UPDATE"
+  metadata {
+    contents_delta_uri = "gs://${google_storage_bucket.main.name}/vector-search-index"
+    config {
+      dimensions                  = 768
+      approximate_neighbors_count = 150
+      shard_size                  = "SHARD_SIZE_SMALL"
+      distance_measure_type       = "SQUARED_L2_DISTANCE"
+      algorithm_config {
+        tree_ah_config {
+          leaf_node_embedding_count    = 1000
+          leaf_nodes_to_search_percent = 10
+        }
+      }
+    }
+  }
+  depends_on = [google_storage_bucket_object.index_initial]
+}
+
+resource "google_vertex_ai_index_endpoint" "docs" {
+  project                 = module.project_services.project_id
+  region                  = var.region
+  display_name            = "docs-index-endpoint"
+  public_endpoint_enabled = true
+}
+
+resource "google_storage_bucket_object" "index_initial" {
+  bucket = google_storage_bucket.main.name
+  name   = "vector-search-index/initial.json"
+  source = abspath("initial-index.json")
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,12 +14,47 @@
  * limitations under the License.
  */
 
-output "neos_walkthrough_url" {
-  value       = "https://console.cloud.google.com/products/solutions/deployments?walkthrough_id=panels--sic--document-summarization-gcf_tour"
-  description = "The URL to launch the in-console tutorial for the Generative AI Document Summarization solution"
+output "neos_tutorial_url" {
+  value       = "https://console.cloud.google.com/products/solutions/deployments?walkthrough_id=panels--sic--generative-ai-knowledge-base_toc"
+  description = "The URL to launch the in-console tutorial for the Generative AI Knowledge Base solution"
 }
 
-output "genai_doc_summary_colab_url" {
-  value       = "https://colab.research.google.com/github/GoogleCloudPlatform/terraform-google-gen-ai-document-summarization/blob/main/notebook/gen_ai_jss.ipynb"
-  description = "The URL to launch the notebook tutorial for the Generateive AI Document Summarization Solution"
+output "predictions_notebook_url" {
+  value       = "https://colab.research.google.com/github/GoogleCloudPlatform/terraform-genai-knowledge-base/blob/main/notebooks/model-predictions.ipynb"
+  description = "The URL to open the notebook for model predictions in Colab"
+}
+
+output "unique_id" {
+  value       = random_id.unique_id.hex
+  description = "The unique ID for this deployment"
+}
+
+output "bucket_main_name" {
+  value       = google_storage_bucket.main.name
+  description = "The name of the main bucket created"
+}
+
+output "bucket_docs_name" {
+  value       = google_storage_bucket.docs.name
+  description = "The name of the docs bucket created"
+}
+
+output "documentai_processor_id" {
+  value       = google_document_ai_processor.ocr.id
+  description = "The full Document AI processor path ID"
+}
+
+output "firestore_database_name" {
+  value       = google_firestore_database.main.name
+  description = "The name of the Firestore database created"
+}
+
+output "docs_index_id" {
+  value       = google_vertex_ai_index.docs.id
+  description = "The ID of the docs index"
+}
+
+output "docs_index_endpoint_id" {
+  value       = google_vertex_ai_index_endpoint.docs.id
+  description = "The ID of the docs index endpoint"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,47 +14,50 @@
  * limitations under the License.
  */
 
+# Jump Start Solution variables.
 variable "project_id" {
   description = "The Google Cloud project ID to deploy to"
   type        = string
   validation {
     condition     = var.project_id != ""
-    error_message = "Error: project_id is required"
+    error_message = "Error: project_id is required."
   }
 }
 
-variable "bucket_name" {
-  description = "The name of the bucket to create"
-  type        = string
-  default     = "genai-webhook"
-}
-
 variable "region" {
-  description = "Google Cloud region"
+  description = "The Google Cloud region to deploy to"
   type        = string
   default     = "us-central1"
 }
 
-variable "webhook_name" {
-  description = "Name of the webhook"
+# Optional variables
+variable "documentai_location" {
+  description = "Document AI location, see https://cloud.google.com/document-ai/docs/regions"
   type        = string
-  default     = "webhook"
+  default     = "us"
 }
 
+variable "firestore_location" {
+  description = "Firestore location, see https://firebase.google.com/docs/firestore/locations"
+  type        = string
+  default     = "nam5" # US
+}
+
+variable "disable_services_on_destroy" {
+  description = "Whether project services will be disabled when the resources are destroyed."
+  type        = bool
+  default     = false
+}
+
+# Used for testing.
 variable "webhook_path" {
-  description = "Path to the webhook directory"
+  description = "Path to the webhook source directory"
   type        = string
   default     = "webhook"
 }
 
-variable "gcf_timeout_seconds" {
-  description = "GCF execution timeout"
-  type        = number
-  default     = 900
-}
-
-variable "time_to_enable_apis" {
-  description = "Wait time to enable APIs in new projects"
-  type        = string
-  default     = "180s"
+variable "unique_names" {
+  description = "Whether to use unique names for resources"
+  type        = bool
+  default     = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,31 +19,23 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.66, < 5.22"
+      version = "~> 5.8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.70"
+      version = "~> 5.8"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = ">= 2"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.2"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.11.0"
+      version = "~> 2.4"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.4"
+      version = "~> 3.5"
     }
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/gen-ai-document-summarization/v0.1.1"
+    module_name = "blueprints/terraform/genai-knowledge-base/v0.1.1"
   }
 }


### PR DESCRIPTION
* Do not merge this pull-request.
* We're working on onboarding JSS 22.1 (https://github.com/GoogleCloudPlatform/terraform-genai-knowledge-base) via https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/2230.
    * In the meantime, I want to make sure Terraform from JSS 22.1 would pass the Blueprint integration tests (e.g., test on "LOW REPUTATION" users).