### PR TITLE
fix: Pin Google provider to 5.37.0 & set LOG_EXECUTION_ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,11 +98,12 @@ resource "google_cloudfunctions2_function" "webhook" {
     available_memory      = "1G"
     service_account_email = google_service_account.webhook.email
     environment_variables = {
-      OUTPUT_BUCKET   = google_storage_bucket.main.name
-      DOCAI_PROCESSOR = google_document_ai_processor.ocr.id
-      DOCAI_LOCATION  = google_document_ai_processor.ocr.location
-      BQ_DATASET      = google_bigquery_dataset.main.dataset_id
-      BQ_TABLE        = google_bigquery_table.main.table_id
+      OUTPUT_BUCKET    = google_storage_bucket.main.name
+      DOCAI_PROCESSOR  = google_document_ai_processor.ocr.id
+      DOCAI_LOCATION   = google_document_ai_processor.ocr.location
+      BQ_DATASET       = google_bigquery_dataset.main.dataset_id
+      BQ_TABLE         = google_bigquery_table.main.table_id
+      LOG_EXECUTION_ID = true
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.24, < 6"
+      version = "= 5.37.0, < 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.24, < 6"
+      version = "= 5.37.0, < 6"
     }
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/terraform-genai-knowledge-base/pull/166. (Identical issue with the "GenAI Knowledge Base" Jump Start Solution.)