### PR TITLE
Delete BigQuery Record on GCS File Removal

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,6 +179,31 @@ resource "google_eventarc_trigger" "trigger" {
   }
 }
 
+#-- Eventarc trigger for deletion events --#
+resource "google_eventarc_trigger" "delete_trigger" {
+  project         = module.project_services.project_id
+  location        = var.region
+  name            = "${local.trigger_name}-delete"
+  service_account = google_service_account.trigger.email
+  labels          = var.labels
+
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.storage.object.v1.deleted"
+  }
+  matching_criteria {
+    attribute = "bucket"
+    value     = google_storage_bucket.docs.name
+  }
+
+  destination {
+    cloud_run_service {
+      service = google_cloudfunctions2_function.webhook.name
+      region  = var.region
+    }
+  }
+}
+
 resource "google_project_iam_member" "trigger" {
   project = module.project_services.project_id
   member  = google_service_account.trigger.member

--- a/webhook/main.py
+++ b/webhook/main.py
@@ -29,26 +29,37 @@ from google.cloud import storage  # type: ignore
 
 @functions_framework.cloud_event
 def on_cloud_event(event: CloudEvent) -> None:
-    """Process a new document from an Eventarc event.
+    """Process a document event from an Eventarc event.
 
     Args:
         event: CloudEvent object.
     """
     try:
-        process_document(
-            event_id=event.data["id"],
-            input_bucket=event.data["bucket"],
-            filename=event.data["name"],
-            mime_type=event.data["contentType"],
-            time_uploaded=datetime.fromisoformat(event.data["timeCreated"]),
-            project=os.environ["PROJECT_ID"],
-            location=os.environ["LOCATION"],
-            docai_processor_id=os.environ["DOCAI_PROCESSOR"],
-            docai_location=os.environ.get("DOCAI_LOCATION", "us"),
-            output_bucket=os.environ["OUTPUT_BUCKET"],
-            bq_dataset=os.environ["BQ_DATASET"],
-            bq_table=os.environ["BQ_TABLE"],
-        )
+        event_type = event.data.get("type", "")
+        if event_type == "google.cloud.storage.object.v1.finalized":
+            process_document(
+                event_id=event.data["id"],
+                input_bucket=event.data["bucket"],
+                filename=event.data["name"],
+                mime_type=event.data["contentType"],
+                time_uploaded=datetime.fromisoformat(event.data["timeCreated"]),
+                project=os.environ["PROJECT_ID"],
+                location=os.environ["LOCATION"],
+                docai_processor_id=os.environ["DOCAI_PROCESSOR"],
+                docai_location=os.environ.get("DOCAI_LOCATION", "us"),
+                output_bucket=os.environ["OUTPUT_BUCKET"],
+                bq_dataset=os.environ["BQ_DATASET"],
+                bq_table=os.environ["BQ_TABLE"],
+            )
+        elif event_type == "google.cloud.storage.object.v1.deleted":
+            delete_document(
+                event_id=event.data["id"],
+                input_bucket=event.data["bucket"],
+                filename=event.data["name"],
+                project=os.environ["PROJECT_ID"],
+                bq_dataset=os.environ["BQ_DATASET"],
+                bq_table=os.environ["BQ_TABLE"],
+            )
     except Exception as e:
         logging.exception(e, stack_info=True)
 
@@ -223,3 +234,42 @@ def write_to_bigquery(
             },
         ],
     )
+
+
+def delete_document(
+    event_id: str,
+    input_bucket: str,
+    filename: str,
+    project: str,
+    bq_dataset: str,
+    bq_table: str,
+) -> None:
+    """Delete a document summary from BigQuery when the source document is deleted.
+
+    Args:
+        event_id: ID of the event.
+        input_bucket: Name of the input bucket.
+        filename: Name of the deleted file.
+        project: Google Cloud project ID.
+        bq_dataset: Name of the BigQuery dataset.
+        bq_table: Name of the BigQuery table.
+    """
+    doc_path = f"gs://{input_bucket}/{filename}"
+    print(f"🗑️ {event_id}: Removing document summary from BigQuery: {project}.{bq_dataset}.{bq_table}")
+    
+    bq_client = bigquery.Client(project=project)
+    query = f"""
+    DELETE FROM `{project}.{bq_dataset}.{bq_table}`
+    WHERE document_path = @doc_path
+    """
+    
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("doc_path", "STRING", doc_path),
+        ]
+    )
+    
+    query_job = bq_client.query(query, job_config=job_config)
+    query_job.result()  # Wait for the query to complete
+    
+    print(f"✅ {event_id}: Document summary removed from BigQuery!")


### PR DESCRIPTION
This PR implements an automated cleanup process that deletes the corresponding BigQuery record when a file is removed from Google Cloud Storage. This change ensures consistency between our storage and database systems, preventing orphaned records in BigQuery.